### PR TITLE
Drop Ruby < 2.5 support

### DIFF
--- a/simplecov_lcov_formatter.gemspec
+++ b/simplecov_lcov_formatter.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/t-mario-y/simplecov_lcov_formatter'
   s.licenses = 'MIT'
 
+  s.required_ruby_version = '>= 2.5'
+
   s.add_development_dependency('activesupport', '> 0')
   s.add_development_dependency('rspec', '> 0')
   s.add_development_dependency('syntax_tree', '> 0')


### PR DESCRIPTION
Instead of going for 2.4, which is the minimum required Ruby version by
simplecov 0.18, it has been decided to go for 2.5 and newer

Ref: #5
