### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/simplecov_lcov_formatter.gemspec
+++ b/simplecov_lcov_formatter.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
+  s.metadata['rubygems_mfa_required'] = 'true'
+
   s.add_development_dependency('activesupport', '> 0')
   s.add_development_dependency('rspec', '> 0')
   s.add_development_dependency('syntax_tree', '> 0')


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by
any of the owners require OTP.

Ref:
- https://guides.rubygems.org/mfa-requirement-opt-in/
- t-mario-y#5