### PR TITLE
Replace `Array#filter` with `Array#count`

### DIFF
--- a/lib/simplecov_lcov_formatter.rb
+++ b/lib/simplecov_lcov_formatter.rb
@@ -81,8 +81,8 @@ module SimpleCov
         pieces = []
         pieces << "SF:#{filename}"
         pieces << format_lines(file)
-        pieces << "LF:#{file.lines.filter { |el| el.coverage }.count}"
-        pieces << "LH:#{file.lines.filter { |el| el.coverage && el.coverage > 0 }.count}"
+        pieces << "LF:#{file.lines.count { |el| el.coverage }}"
+        pieces << "LH:#{file.lines.count { |el| el.coverage && el.coverage > 0 }}"
 
         if SimpleCov.branch_coverage?
           branch_data = format_branches(file)


### PR DESCRIPTION
`Array#filter` has been introduced in Ruby 2.6 as an alias of
`Array#select`.

Moreover, it is possible to use `Array#count` with a block instead
of filtering and counting

This commit switches to `Array#count` to fix Ruby 2.5 compatibility
and improve IPS and memory performance

```
%i[ips memory].each do |benchmark|
  Benchmark.send(benchmark) do |x|
    x.report('select') { [1,2,3].select { |d| d.odd? }.count }
    x.report('count') { [1,2,3].count { |d| d.odd? } }
    x.compare!
  end
end

Comparison (IPS):
               count:  6920204.9 i/s
              select:  5783214.4 i/s - 1.20x  (± 0.00) slower

Comparison (Memory):
               count:         40 allocated
              select:         80 allocated - 2.00x more
```

Close #10

---

Green build: https://github.com/tagliala/simplecov_lcov_formatter/actions/runs/13225194991