### PR TITLE
release 1.0.0

### DIFF
--- a/lib/simplecov_lcov_formatter/version.rb
+++ b/lib/simplecov_lcov_formatter/version.rb
@@ -1,3 +1,3 @@
 module SimpleCovLcovFormatter
-  VERSION = '0.9.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
`1.0.0` because we explicitly drop Ruby 2.5 support. https://github.com/t-mario-y/simplecov_lcov_formatter/pull/6