### PR TITLE
Fix RuboCop offenses in production code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+Style/NumericPredicate:
+  Enabled: false
+
 # TODO: Syntax Tree uses double_quotes, but does not raise a warning
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,23 +37,6 @@ Style/ClassAndModuleChildren:
     - 'spec/spec_helper.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, always_true, never
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - '**/*.arb'
-    - 'lib/simplecov_lcov_formatter.rb'
-    - 'lib/simplecov_lcov_formatter/configuration.rb'
-    - 'lib/simplecov_lcov_formatter/version.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: literals, strict
-Style/MutableConstant:
-  Exclude:
-    - 'lib/simplecov_lcov_formatter/version.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle, AllowedMethods, AllowedPatterns.
 # SupportedStyles: predicate, comparison
 Style/NumericPredicate:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,11 +35,3 @@ Style/ClassAndModuleChildren:
   Exclude:
     - 'spec/simplecov_lcov_formatter_spec.rb'
     - 'spec/spec_helper.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle, AllowedMethods, AllowedPatterns.
-# SupportedStyles: predicate, comparison
-Style/NumericPredicate:
-  Exclude:
-    - 'spec/**/*'
-    - 'lib/simplecov_lcov_formatter.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 29
+  Max: 28
 
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
@@ -42,9 +42,4 @@ Style/ClassAndModuleChildren:
 Style/NumericPredicate:
   Exclude:
     - 'spec/**/*'
-    - 'lib/simplecov_lcov_formatter.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/ZeroLengthPredicate:
-  Exclude:
     - 'lib/simplecov_lcov_formatter.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 30
+  Max: 29
 
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
@@ -42,13 +42,6 @@ Style/ClassAndModuleChildren:
 Style/NumericPredicate:
   Exclude:
     - 'spec/**/*'
-    - 'lib/simplecov_lcov_formatter.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowMethodsWithArguments, AllowedMethods, AllowedPatterns, AllowComments.
-# AllowedMethods: define_method
-Style/SymbolProc:
-  Exclude:
     - 'lib/simplecov_lcov_formatter.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,11 +14,6 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Max: 15
 
-# This cop supports safe autocorrection (--autocorrect).
-Performance/StringReplacement:
-  Exclude:
-    - 'lib/simplecov_lcov_formatter.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: SkipBlocks, EnforcedStyle, OnlyStaticConstants.
 # SupportedStyles: described_class, explicit
@@ -33,13 +28,6 @@ RSpec/SpecFilePathFormat:
     - '**/spec/routing/**/*'
     - 'spec/configuration_spec.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: separated, grouped
-Style/AccessorGrouping:
-  Exclude:
-    - 'lib/simplecov_lcov_formatter/configuration.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: nested, compact
@@ -47,11 +35,6 @@ Style/ClassAndModuleChildren:
   Exclude:
     - 'spec/simplecov_lcov_formatter_spec.rb'
     - 'spec/spec_helper.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-Style/FileWrite:
-  Exclude:
-    - 'lib/simplecov_lcov_formatter.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.

--- a/lib/simplecov_lcov_formatter.rb
+++ b/lib/simplecov_lcov_formatter.rb
@@ -84,7 +84,7 @@ module SimpleCov
         pieces = []
         pieces << "SF:#{filename}"
         pieces << format_lines(file)
-        pieces << "LF:#{file.lines.count { |el| el.coverage }}"
+        pieces << "LF:#{file.lines.count(&:coverage)}"
         pieces << "LH:#{file.lines.count { |el| el.coverage && el.coverage > 0 }}"
 
         if SimpleCov.branch_coverage?

--- a/lib/simplecov_lcov_formatter.rb
+++ b/lib/simplecov_lcov_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'pathname'
 require 'simplecov'

--- a/lib/simplecov_lcov_formatter.rb
+++ b/lib/simplecov_lcov_formatter.rb
@@ -89,7 +89,7 @@ module SimpleCov
 
         if SimpleCov.branch_coverage?
           branch_data = format_branches(file)
-          pieces << branch_data if branch_data.length > 0
+          pieces << branch_data unless branch_data.empty?
           pieces << "BRF:#{file.total_branches.length}"
           pieces << "BRH:#{file.covered_branches.length}"
         end

--- a/lib/simplecov_lcov_formatter.rb
+++ b/lib/simplecov_lcov_formatter.rb
@@ -66,7 +66,7 @@ module SimpleCov
       end
 
       def write_lcov!(file)
-        File.open(File.join(output_directory, output_filename(file.filename)), 'w') { |f| f.write format_file(file) }
+        File.write(File.join(output_directory, output_filename(file.filename)), format_file(file))
       end
 
       def write_lcov_to_single_file!(files)
@@ -74,7 +74,7 @@ module SimpleCov
       end
 
       def output_filename(filename)
-        filename.gsub("#{SimpleCov.root}/", '').gsub('/', '-').tap { |name| name << '.lcov' }
+        filename.gsub("#{SimpleCov.root}/", '').tr('/', '-').tap { |name| name << '.lcov' }
       end
 
       def format_file(file)

--- a/lib/simplecov_lcov_formatter/configuration.rb
+++ b/lib/simplecov_lcov_formatter/configuration.rb
@@ -1,8 +1,6 @@
 module SimpleCovLcovFormatter
   class Configuration
-    attr_writer :report_with_single_file
-    attr_writer :output_directory
-    attr_writer :lcov_file_name
+    attr_writer :report_with_single_file, :output_directory, :lcov_file_name
 
     def report_with_single_file?
       !!@report_with_single_file

--- a/lib/simplecov_lcov_formatter/configuration.rb
+++ b/lib/simplecov_lcov_formatter/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SimpleCovLcovFormatter
   class Configuration
     attr_writer :report_with_single_file, :output_directory, :lcov_file_name

--- a/lib/simplecov_lcov_formatter/version.rb
+++ b/lib/simplecov_lcov_formatter/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SimpleCovLcovFormatter
   VERSION = '0.9.0'
 end


### PR DESCRIPTION
### Autofix safe offenses in production code 

- Performance/StringReplacement
- Style/AccessorGrouping
- Style/FileWrite

### Enable Frozen String Literal in production code

### Fix Style/SymbolProc offense

### Fix Style/ZeroLengthPredicate offense 

`format_branches` returns a string, so it is possible to check for
`String#empty?`

### Disable Style/NumericPredicate cop
